### PR TITLE
Improved colors.py

### DIFF
--- a/src/colors.py
+++ b/src/colors.py
@@ -18,7 +18,7 @@ special = {'face': '\02', 'heart': '\03', 'right': '\020',
 
 
 def ansi(code):
-    "Given a code num produce a ansi escape"
+    """Given a code num produce a ansi escape"""
     if isinstance(code, (tuple, list, set)):
         code = ';'.join(code)
     return ANSI_ESCAPE.format(code)
@@ -84,4 +84,3 @@ def background(name):
 
 def wrap(s, c):
     return c+s+CODES['resetall']
-

--- a/src/colors.py
+++ b/src/colors.py
@@ -83,4 +83,5 @@ def background(name):
 
 
 def wrap(s, c):
-    return s+c+CODES['resetall']
+    return c+s+CODES['resetall']
+

--- a/src/colors.py
+++ b/src/colors.py
@@ -1,36 +1,86 @@
-## ANSI color helper
+"""
+ANSI Color Helpers
+"""
+import re
+import string
+
+
+ANSI_ESCAPE = '\x1b[{}m'
+ANSI_RE = re.compile('\x1b\[((?:\d|;)*)m')
+GROUPED_ANSI_RE = re.compile('((?:\x1b\[(?:\d|;)*m\s*)+)')
+WHITESPACE_RE = re.compile('\s+')
+
+COLORS = ('black', 'red', 'green', 'yellow', 'blue',
+          'magenta', 'cyan', 'white')
+
+special = {'face': '\02', 'heart': '\03', 'right': '\020',
+           'down': '\037', 'up': '\036'}
+
+
+def ansi(code):
+    "Given a code num produce a ansi escape"
+    if isinstance(code, (tuple, list, set)):
+        code = ';'.join(code)
+    return ANSI_ESCAPE.format(code)
+
+
+CODES = {'resetall': ansi(0),
+         'bold': ansi(1),
+         'underline': ansi(4),
+         'blink': ansi(5),
+         'reverse': ansi(7),
+         'boldoff': ansi(22),
+         'blinkoff': ansi(25),
+         'underlineoff': ansi(24),
+         'reverseoff': ansi(27),
+         'reset': ansi(39),
+         'RESET': ansi(49)}
+
+# fill in colors
+for index, name in enumerate(COLORS):
+    CODES[name] = ansi(index + 30)
+    CODES[name.upper()] = ansi(index + 40)
+
+
+def unstyle(text):
+    """Remove all ANSI styling"""
+    return ANSI_RE.sub('', text)
+
+
+def _compress_ansi(matchobj):
+    matched = matchobj.group(0)
+    # We don't want to loose the whitespace between codes
+    ws = WHITESPACE_RE.findall(matched)
+    codes = ANSI_RE.findall(matched)
+    return ansi(codes) + ''.join(ws)
+
+
+def style(text, reset=True):
+    """
+    Text can contain color codes $CODE
+    ALL CAP COLOR NAME = Background Color
+    Templates can contain {} to prevent ambiguity
+
+    The man with the red ${red}hat.
+
+    Unknown codes are left in the styled text
+    :param text: Text to style
+    :param reset: Add resetall to end of string
+    :return: styled text
+    """
+    if reset:
+        text += '$resetall'
+    styled = string.Template(text).safe_substitute(CODES)
+    return GROUPED_ANSI_RE.sub(_compress_ansi, styled)
+
 
 def color(name):
-    codes = {  "reset" :   "\033[01;00m",
-               "bold" :   "\033[01;01m",
-               "boldoff" :   "\033[01;22m",
-                "blue"  :   "\033[01;34m",
-                "black" :   "\033[01;30m",
-                "red"  :   "\033[01;31m",
-                "green"  :   "\033[01;32m",
-                "yellow"  :   "\033[01;33m",
-                "orange" : "\033[48;5;266m",
-                "teal" : "\033[48;5;34m",
-                "magenta"  :   "\033[01;35m",
-                "cyan"  :   "\033[01;36m",
-                "white"  :   "\033[01;37m", }
-    return codes[name]
+    return CODES[name]
+
 
 def background(name):
-    codes = {  "reset" :   "\033[01;00m",
-               "bold" :   "\033[01;01m",
-               "boldoff" :   "\033[01;22m",
-                "blue"  :   "\033[01;44m",
-                "black" :   "\033[01;40m",
-                "red"  :   "\033[01;41m",
-                "green"  :   "\033[01;42m",
-                "yellow"  :   "\033[01;43m",
-                "magenta"  :   "\033[01;45m",
-                "cyan"  :   "\033[01;46m",
-                "white"  :   "\033[01;47m", }
-    return codes[name]
+    return CODES[name.upper()]
 
-special = {"face": "\02", "heart": "\03", "right": "\020", "down": "\037", "up": "\036",}
 
 def wrap(s, c):
-    return c+s+color('reset')+background('reset')
+    return s+c+CODES['resetall']


### PR DESCRIPTION
colors.py had bold code in every color, and there was 256 color codes mixed in without known support from the client. 

I removed the two 256 color codes for some future implementation date, need a good way to downgrade the colors to ansi

I added the style() command, which can take text with $CODE and turn it into ANSI escapes. 

`````` style('${red}nose')```
instead of 
```color('red') + 'nose' + color('reset')```
or
```wrap('nose', color('red'))```
but all methods still work. 

Also style compresses adjacent ansi escape codes into a single escape 
provided unstyle to strip ansi codes from text
``````
